### PR TITLE
Make key structures use int headers

### DIFF
--- a/csharp/COSE/Key.cs
+++ b/csharp/COSE/Key.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 using PeterO.Cbor;
 
+using Org.BouncyCastle.Asn1.Nist;
+using Org.BouncyCastle.Asn1.X9;
+
 namespace COSE
 {
     public class Key
@@ -22,6 +25,11 @@ namespace COSE
             m_map = objKey;
         }
 
+        public void Add(CBORObject key,CBORObject value)
+        {
+            m_map.Add(key, value);
+        }
+
         public void Add(string name, string value)
         {
             m_map.Add(name, value);
@@ -32,10 +40,10 @@ namespace COSE
             m_map.Add(name, value);
         }
 
-        public Org.BouncyCastle.Math.BigInteger AsBigInteger(string keyName)
+        public Org.BouncyCastle.Math.BigInteger AsBigInteger(CBORObject keyName)
         {
 
-            byte[] rgb = AsBytes(keyName);
+            byte[] rgb = m_map[keyName].GetByteString();
             byte[] rgb2 = new byte[rgb.Length + 2];
             rgb2[0] = 0;
             rgb2[1] = 0;
@@ -69,6 +77,11 @@ namespace COSE
             return m_map.ContainsKey(name);
         }
 
+        public Boolean ContainsName(CBORObject key)
+        {
+            return m_map.ContainsKey(key);
+        }
+
         public byte[] EncodeToBytes()
         {
             return m_map.EncodeToBytes();
@@ -79,5 +92,30 @@ namespace COSE
             return m_map;
         }
 
+        public X9ECParameters GetCurve()
+        {
+            CBORObject cborKeyType = m_map[CoseKeyKeys.KeyType];
+
+            if (cborKeyType == null) throw new CoseException("Malformed key struture");
+            if ((cborKeyType.Type != CBORType.Number) && (cborKeyType != GeneralValues.KeyType_EC)) throw new CoseException("Not an EC key");
+
+            CBORObject cborCurve = m_map[CoseKeyParameterKeys.EC_Curve];
+            if (cborCurve.Type == CBORType.Number) {
+                switch ((GeneralValuesInt) cborCurve.AsInt32()) {
+                case GeneralValuesInt.P256: return NistNamedCurves.GetByName("P-256");
+                case GeneralValuesInt.P521: return NistNamedCurves.GetByName("P-521");
+                default:
+                    throw new CoseException("Unsupported key type: " + cborKeyType.AsInt32());
+                }
+            }
+            else if (cborCurve.Type == CBORType.TextString) {
+                switch (cborCurve.AsString()) {
+                case "P-384": return NistNamedCurves.GetByName("P384");
+                default:
+                throw new CoseException("Unsupported key type: " + cborKeyType.AsString());
+                }
+            }
+            else throw new CoseException("Incorrectly encoded key type");
+        }
     }
 }

--- a/csharp/COSE/MACMessage.cs
+++ b/csharp/COSE/MACMessage.cs
@@ -23,8 +23,6 @@ namespace COSE
 {
     public class MACMessage : Message
     {
-        CBORObject obj;
-
         byte[] rgbTag;
         byte[] rgbContent;
 

--- a/csharp/COSE/Message.cs
+++ b/csharp/COSE/Message.cs
@@ -72,6 +72,46 @@ namespace COSE
         static public readonly CBORObject RSA_PSS_512 = CBORObject.FromObject(AlgorithmValuesInt.RSA_PSS_512);
     }
 
+    public class CoseKeyKeys
+    {
+        static public readonly CBORObject KeyType = CBORObject.FromObject(1);
+        static public readonly CBORObject KeyIdentifier = CBORObject.FromObject(2);
+        static public readonly CBORObject Algorithm = CBORObject.FromObject(3);
+        static public readonly CBORObject Key_Operations = CBORObject.FromObject("key_ops");
+        static public readonly CBORObject x5u = CBORObject.FromObject("x5u");
+        static public readonly CBORObject x5c = CBORObject.FromObject("x5c");
+        static public readonly CBORObject x5t = CBORObject.FromObject("x5t");
+        static public readonly CBORObject x5t_sha_256 = CBORObject.FromObject("x5t#S256");
+    }
+
+    public class CoseKeyParameterKeys
+    {
+        static public readonly CBORObject EC_Curve = CBORObject.FromObject(-1);
+        static public readonly CBORObject EC_X = CBORObject.FromObject(-2);
+        static public readonly CBORObject EC_Y = CBORObject.FromObject(-3);
+        static public readonly CBORObject EC_D = CBORObject.FromObject("d");
+
+        static public readonly CBORObject RSA_e = CBORObject.FromObject(-1);
+        static public readonly CBORObject RSA_n = CBORObject.FromObject(-2);
+    }
+
+    public enum GeneralValuesInt
+    {
+        KeyType_EC = 1, KeyType_RSA=2, KeyType_Octet = 3,
+        P256=4, P521=5,
+
+    }
+
+    public class GeneralValues
+    {
+        static public readonly CBORObject KeyType_EC = CBORObject.FromObject(GeneralValuesInt.KeyType_EC);
+        static public readonly CBORObject KeyType_RSA = CBORObject.FromObject(GeneralValuesInt.KeyType_RSA);
+        static public readonly CBORObject KeyType_Octet = CBORObject.FromObject(GeneralValuesInt.KeyType_Octet);
+        static public readonly CBORObject P256 = CBORObject.FromObject(GeneralValuesInt.P256);
+        static public readonly CBORObject P521 = CBORObject.FromObject(GeneralValuesInt.P521);
+
+    }
+
     public abstract class Message : Attributes
     {
         protected bool m_forceArray = false;

--- a/csharp/JOSE/EncryptMessage.cs
+++ b/csharp/JOSE/EncryptMessage.cs
@@ -1202,8 +1202,8 @@ namespace JOSE
             epk.Add("kty", "EC");
             epk.Add("crv", m_key.AsString("crv"));
             ECPublicKeyParameters priv = (ECPublicKeyParameters) p1.Public;
-            epk.Add("x", priv.Q.X.ToBigInteger().ToByteArrayUnsigned());
-            epk.Add("y", priv.Q.Y.ToBigInteger().ToByteArrayUnsigned());
+            epk.Add("x", priv.Q.Normalize().XCoord.ToBigInteger().ToByteArrayUnsigned());
+            epk.Add("y", priv.Q.Normalize().YCoord.ToBigInteger().ToByteArrayUnsigned());
 
             if (msg.FindAttribute("epk", true) != null) msg.AddAttribute("epk", epk, true);
             else if (msg.FindAttribute("epk", false) != null) msg.AddAttribute("epk", epk, false);


### PR DESCRIPTION
Use integer headers for key structures.
Get some small fixes working to make all of the examples look right.